### PR TITLE
Increase z index of chat floating modal

### DIFF
--- a/src/components/chat/ChatFloatingModal.module.sass
+++ b/src/components/chat/ChatFloatingModal.module.sass
@@ -4,7 +4,7 @@
   position: fixed
   bottom: 30px
   right: 30px
-  z-index: 1
+  z-index: 1000
   display: flex
   flex-direction: column
   align-items: flex-end


### PR DESCRIPTION
# Problem
Currently, the button will overlap in mobile of `/` route. Need z-index of minimum 1000 for the chat to appear above them.
I have checked and it won't be on top of modals, because modals themselves have 1000 z-index.

Previously, I decrease it to make the chat be on bottom of the profile popup.
![image](https://user-images.githubusercontent.com/53143942/234749760-3ff42db7-e714-47b5-b618-bf425d6c5cbd.png)
But changing that creates bigger issues, so I think its okay for the chat to be on top of profile popup