### PR TITLE
Fix issue where creators page get rendered without css for fraction of second

### DIFF
--- a/src/layout/DefaultNav.tsx
+++ b/src/layout/DefaultNav.tsx
@@ -1,0 +1,37 @@
+import { useSidebarCollapsed } from '@/components/providers/SideBarCollapsedContext'
+import { Drawer } from 'antd'
+import clsx from 'clsx'
+import dynamic from 'next/dynamic'
+import { useRouter } from 'next/router'
+import { FunctionComponent, useEffect } from 'react'
+
+const Menu = dynamic(() => import('./SideMenu'), { ssr: false })
+
+const DefaultNav: FunctionComponent<{ className?: string }> = ({
+  className,
+}) => {
+  const {
+    state: { collapsed },
+    hide,
+  } = useSidebarCollapsed()
+  const { asPath } = useRouter()
+
+  useEffect(() => hide(), [ asPath ])
+
+  return (
+    <Drawer
+      className={clsx('DfSideBar h-100', className)}
+      bodyStyle={{ padding: 0 }}
+      placement='left'
+      closable={false}
+      onClose={hide}
+      visible={!collapsed}
+      getContainer={false}
+      keyboard
+    >
+      <Menu />
+    </Drawer>
+  )
+}
+
+export default DefaultNav

--- a/src/layout/HomeNav.tsx
+++ b/src/layout/HomeNav.tsx
@@ -1,0 +1,20 @@
+import Sider from 'antd/lib/layout/Sider'
+import dynamic from 'next/dynamic'
+
+const Menu = dynamic(() => import('./SideMenu'), { ssr: false })
+
+const HomeNav = () => {
+  return (
+    <Sider
+      className='DfSider'
+      width='230'
+      trigger={null}
+      collapsible
+      collapsed={true}
+    >
+      <Menu />
+    </Sider>
+  )
+}
+
+export default HomeNav

--- a/src/layout/Navigation.tsx
+++ b/src/layout/Navigation.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useEffect, useMemo } from 'react'
-import { Layout, Drawer } from 'antd'
+import React, { useMemo } from 'react'
+import { Layout } from 'antd'
 import { useSidebarCollapsed } from '../components/providers/SideBarCollapsedContext'
 import { useRouter } from 'next/router'
 import clsx from 'clsx'
@@ -7,45 +7,15 @@ import dynamic from 'next/dynamic'
 import styles from './Sider.module.sass'
 import { useCurrentAccount } from '../components/providers/MyExtensionAccountsContext'
 
+const DefaultNav = dynamic(() => import('./DefaultNav'), { ssr: false })
+const HomeNav = dynamic(() => import('./HomeNav'), { ssr: false })
 const TopMenu = dynamic(() => import('../components/topMenu/TopMenu'), { ssr: false })
-const Menu = dynamic(() => import('./SideMenu'), { ssr: false })
 
-const { Sider, Content } = Layout
+const { Content } = Layout
 interface Props {
   children: React.ReactNode
 }
 
-const HomeNav = () => {
-  return <Sider
-    className='DfSider'
-    width='230'
-    trigger={null}
-    collapsible
-    collapsed={true}
-  >
-    <Menu />
-  </Sider>
-}
-
-const DefaultNav: FunctionComponent<{ className?: string }> = ({ className }) => {
-  const { state: { collapsed }, hide } = useSidebarCollapsed()
-  const { asPath } = useRouter()
-
-  useEffect(() => hide(), [ asPath ])
-
-  return <Drawer
-    className={clsx('DfSideBar h-100', className)}
-    bodyStyle={{ padding: 0 }}
-    placement='left'
-    closable={false}
-    onClose={hide}
-    visible={!collapsed}
-    getContainer={false}
-    keyboard
-  >
-    <Menu />
-  </Drawer>
-}
 
 const Navigation = (props: Props): JSX.Element => {
   const { children } = props

--- a/src/layout/NextLayout.tsx
+++ b/src/layout/NextLayout.tsx
@@ -12,11 +12,14 @@ import { MINUTES } from '../components/utils/index'
 import dynamic from 'next/dynamic'
 import AnalyticProvider from 'src/components/providers/AnalyticContext'
 import { ChatContextWrapper } from 'src/components/providers/ChatContext'
+import Navigation from './Navigation'
 
-const Navigation = dynamic(() => import('./Navigation'), { ssr: false })
-const ChatFloatingModal = dynamic(() => import('src/components/chat/ChatFloatingModal'), {
-  ssr: false
-})
+const ChatFloatingModal = dynamic(
+  () => import('src/components/chat/ChatFloatingModal'),
+  {
+    ssr: false,
+  }
+)
 
 const Page: React.FunctionComponent = ({ children }) => (
   <>


### PR DESCRIPTION
Issue:
The <Head> which adding the tailwind.css is not called from server side (making the html doesn't include the <style> tag). This is because <Navigation> is rendered dynamically without ssr, which makes the content also not included in the resulting html

Solution:
Move the dynamic import so that the content of the navigation is the one dynamically imported, while the navigation itself along with the content is rendered directly