### PR TITLE
Add custom transfer for kusama

### DIFF
--- a/src/components/transfer/configs/same-chain.ts
+++ b/src/components/transfer/configs/same-chain.ts
@@ -15,6 +15,12 @@ const customSameChainTransferConfig: {
     extrinsic: string
   }
 } = {
+  [getCustomTransferParamId('KSM', 'kusama')]: {
+    extrinsic: 'balances.transferAllowDeath',
+    getParams: (data) => {
+      return [ data.recipient, data.amount ]
+    },
+  },
   [getCustomTransferParamId('MGX', 'mangata')]: {
     extrinsic: 'tokens.transfer',
     getParams: (data) => {


### PR DESCRIPTION
Balances.transfer is deprecated in kusama, instead, use balances.transferAllowDeath